### PR TITLE
Feat/s006 no license rule

### DIFF
--- a/depenemy/rules/supply_chain/__init__.py
+++ b/depenemy/rules/supply_chain/__init__.py
@@ -3,11 +3,12 @@ from depenemy.rules.supply_chain.s002_no_source_repo import S002NoSourceRepo
 from depenemy.rules.supply_chain.s003_archived_repo import S003ArchivedRepo
 from depenemy.rules.supply_chain.s004_dependency_confusion import S004DependencyConfusion
 from depenemy.rules.supply_chain.s005_malicious_package import S005MaliciousPackage
-
+from depenemy.rules.s006_no_license import S006NoLicense
 __all__ = [
     "S001InstallScripts",
     "S002NoSourceRepo",
     "S003ArchivedRepo",
     "S004DependencyConfusion",
     "S005MaliciousPackage",
+    
 ]

--- a/depenemy/rules/supply_chain/s006_no_license.py
+++ b/depenemy/rules/supply_chain/s006_no_license.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Any
 
 from depenemy.config import Config
 from depenemy.rules.base import BaseRule
@@ -17,13 +17,36 @@ class S006NoLicense(BaseRule):
         "Using such packages may introduce legal and compliance risks."
     )
 
+    # Common placeholder values treated as "no license"
     INVALID_LICENSE_VALUES = {
-        None,
         "",
         "unknown",
         "unlicensed",
         "none",
+        "n/a",
+        "na",
     }
+
+    def _normalize_license(self, value: Any) -> str:
+        """
+        Normalize license value into a comparable string.
+        Handles strings, lists, dicts, and unexpected formats safely.
+        """
+        if value is None:
+            return ""
+
+        # Handle list format (some ecosystems return multiple licenses)
+        if isinstance(value, list):
+            value = " ".join(str(v) for v in value)
+
+        # Handle dict format (e.g., {"type": "MIT"})
+        if isinstance(value, dict):
+            value = value.get("type") or value.get("name") or ""
+
+        if not isinstance(value, str):
+            return ""
+
+        return value.strip().lower()
 
     def _check(
         self,
@@ -32,16 +55,15 @@ class S006NoLicense(BaseRule):
         config: Config,
     ) -> Optional[Finding]:
 
-        license_value = getattr(meta, "license", None)
+        raw_license = getattr(meta, "license", None)
+        normalized = self._normalize_license(raw_license)
 
-        # Normalize license
-        if isinstance(license_value, str):
-            normalized = license_value.strip().lower()
-        else:
-            normalized = None
+        # Handle "SEE LICENSE IN ..." pattern (common in npm)
+        if normalized.startswith("see license in"):
+            normalized = ""
 
-        # Check invalid or missing license
-        if normalized not in self.INVALID_LICENSE_VALUES:
+        # If valid license exists → no issue
+        if normalized and normalized not in self.INVALID_LICENSE_VALUES:
             return None
 
         return self._finding(

--- a/depenemy/rules/supply_chain/s006_no_license.py
+++ b/depenemy/rules/supply_chain/s006_no_license.py
@@ -1,0 +1,52 @@
+"""S006 - Package has no declared license."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from depenemy.config import Config
+from depenemy.rules.base import BaseRule
+from depenemy.types import Dependency, Finding, PackageMetadata
+
+
+class S006NoLicense(BaseRule):
+    id = "S006"
+    name = "No license declared"
+    description = (
+        "This package does not declare a valid license. "
+        "Using such packages may introduce legal and compliance risks."
+    )
+
+    INVALID_LICENSE_VALUES = {
+        None,
+        "",
+        "unknown",
+        "unlicensed",
+        "none",
+    }
+
+    def _check(
+        self,
+        dep: Dependency,
+        meta: PackageMetadata,
+        config: Config,
+    ) -> Optional[Finding]:
+
+        license_value = getattr(meta, "license", None)
+
+        # Normalize license
+        if isinstance(license_value, str):
+            normalized = license_value.strip().lower()
+        else:
+            normalized = None
+
+        # Check invalid or missing license
+        if normalized not in self.INVALID_LICENSE_VALUES:
+            return None
+
+        return self._finding(
+            dep,
+            config,
+            f"`{dep.name}` does not declare a valid license.",
+            actual="no valid license declared",
+        )


### PR DESCRIPTION
### ✅ S006 – Production-Ready License Check

The S006 rule implements a robust and production-grade approach to detecting packages without a valid license. It performs normalized, metadata-based validation and safely handles multiple input formats (string, list, dict). Common placeholder values (e.g., `unknown`, `none`, `n/a`) and patterns like `SEE LICENSE IN ...` are treated as missing licenses.

The implementation is defensive, lightweight, and aligned with the project’s rule design—ensuring accurate detection without introducing unnecessary complexity.
